### PR TITLE
Update ConfigV3.java

### DIFF
--- a/src/main/java/com/zhipu/oapi/core/ConfigV3.java
+++ b/src/main/java/com/zhipu/oapi/core/ConfigV3.java
@@ -36,7 +36,7 @@ public class ConfigV3 {
 
     public ConfigV3(String apiSecretKey) {
         this.apiSecretKey = apiSecretKey;
-        String[] arrStr = apiSecretKey.split(".");
+        String[] arrStr = apiSecretKey.split("\\.");
         if (arrStr.length != 2) {
             throw new RuntimeException("invalid apiSecretKey");
         }


### PR DESCRIPTION
修复正则使用问题：apiSecretKey.split(".") -> apiSecretKey.split("\\.")